### PR TITLE
Make minimum required version for Gregtech 6.00.00

### DIFF
--- a/src/main/java/pl/asie/lib/AsieLibMod.java
+++ b/src/main/java/pl/asie/lib/AsieLibMod.java
@@ -34,7 +34,7 @@ import java.lang.reflect.Method;
 import java.util.Random;
 
 @Mod(modid = Mods.AsieLib, name = Mods.AsieLib_NAME, version = "@VERSION@",
-	dependencies = "required-after:Forge@[10.13.2.1236,);after:gregtech@[MC1710];"
+	dependencies = "required-after:Forge@[10.13.2.1236,);after:gregtech@[6.00.00];"
 		+ "after:CoFHAPI|block@[1.7.10R1.0.0,);after:CoFHAPI|energy@[1.7.10R1.0.0,);"
 		+ "after:CoFHAPI|tileentity@[1.7.10R1.0.0,);after:CoFHAPI|item@[1.7.10R1.0.0,)")
 public class AsieLibMod extends AsieLibAPI {


### PR DESCRIPTION
Gregtech version 6.xx.xx uses a different version number than the previous "[MC1710]"
